### PR TITLE
add dependency to Microsoft Visual C++ Redistributable for Visual Studio 2015-2022

### DIFF
--- a/msodbcsql/msodbcsql.nuspec
+++ b/msodbcsql/msodbcsql.nuspec
@@ -16,9 +16,6 @@ Microsoft ODBC Driver for SQL Server is a single dynamic-link library (DLL) cont
 
 The redistributable installer for Microsoft ODBC Driver 18 for SQL Server installs the client components, which are required during run time to take advantage of newer SQL Server features. It optionally installs the header files needed to develop an application that uses the ODBC API. Starting with version 17.4.2, the installer also includes and installs the Microsoft Active Directory Authentication Library (ADAL.dll).
     </description>
-    <dependencies>
-      <dependency id="vcredist140" version="14.34" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/msodbcsql/msodbcsql.nuspec
+++ b/msodbcsql/msodbcsql.nuspec
@@ -16,6 +16,9 @@ Microsoft ODBC Driver for SQL Server is a single dynamic-link library (DLL) cont
 
 The redistributable installer for Microsoft ODBC Driver 18 for SQL Server installs the client components, which are required during run time to take advantage of newer SQL Server features. It optionally installs the header files needed to develop an application that uses the ODBC API. Starting with version 17.4.2, the installer also includes and installs the Microsoft Active Directory Authentication Library (ADAL.dll).
     </description>
+    <dependencies>
+      <dependency id="vcredist140" version="14.34" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/msoledbsql/msoledbsql.nuspec
+++ b/msoledbsql/msoledbsql.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>msoledbsql</id>
-    <version>19.3.2.0</version>
+    <version>19.3.2.1</version>
     <packageSourceUrl>https://github.com/fdcastel/chocolatey-packages</packageSourceUrl>    
     <owners>fdcastel</owners>
     <title>Microsoft OLE DB Driver for SQL Server</title>
@@ -18,6 +18,9 @@ Microsoft OLE DB Driver 19 for SQL Server should be used to create new applicati
 
 This redistributable installer for Microsoft OLE DB Driver 19 for SQL Server installs the client components needed during run time to take advantage of newer SQL Server features, and optionally installs the header files needed to develop an application that uses the OLE DB API.
     </description>
+    <dependencies>
+      <dependency id="vcredist140" version="14.34" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Since version 19.3.0 of Microsoft OLE DB Driver for SQL Server there is now a dependency on Microsoft Visual C++ Redistributable for Visual Studio 2022.

The release notes can be found here: [Release notes for the Microsoft OLE DB Driver for SQL Server](https://learn.microsoft.com/en-us/sql/connect/oledb/release-notes-for-oledb-driver-for-sql-server?view=sql-server-ver16#1930)